### PR TITLE
change - to _ in step 9.  so user can copy and paste the command without errors.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Assume the `~/` reflects your project directory, meaning the same directory as t
 ## Ingest Data
 7. Make a copy of `~/parser/env.sample` to `~/parser/.env`.  Optional - customize settings for better security.
 8. Put all your zipped DMARC aggregation reports into the `~/parser/logs/zipped/`.  Sample DMARC aggregration reports can be copied from `~/parser/logs/zipped-sample/`.  The zipped DMARC reports should end with any of the following filename extensions: `*.gz` or `*.zip`.
-9. Type `docker exec -it dmarc-parser-1 ./start.sh` to extract, transform and load DMARC aggregation data into your ELK stack.
+9. Type `docker exec -it dmarc_parser_1 ./start.sh` to extract, transform and load DMARC aggregation data into your ELK stack.
 10. Go to your web browser in Kibana and go to Dashboards to see your DMARC Dashboard.
 
 ![Screenshot](screenshot.png "DMARC Dashboard")


### PR DESCRIPTION
When running the command for step 9 I got an error that the docker container dmarc-parser-1 didn't exist, which was weird because I had all containers running, I then noticed that the - in dmarc-parser-1 should be a _ , after changing that It worked perfectly.

By adding this little change user don't run into this error.

command with fix: docker exec -it dmarc_parser_1 ./start.sh

<img width="650" alt="Scherm­afbeelding 2024-04-08 om 17 51 47" src="https://github.com/evermight/elk-dmarc/assets/104017860/3607f97f-11ba-4e94-9958-08358f17987f">
<img width="657" alt="Scherm­afbeelding 2024-04-08 om 17 51 58" src="https://github.com/evermight/elk-dmarc/assets/104017860/5bc3bd67-bc07-40a2-888a-656fbc923a8c">
